### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/aiw-devops/b89bead0-a04d-4cd1-8d8d-a0a4047570af/b7fdaaa2-ad26-432f-9e7c-30b219e6b31a/_apis/work/boardbadge/a3dad56b-e07f-4af7-9943-e0b003342947)](https://dev.azure.com/aiw-devops/b89bead0-a04d-4cd1-8d8d-a0a4047570af/_boards/board/t/b7fdaaa2-ad26-432f-9e7c-30b219e6b31a/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1292](https://dev.azure.com/aiw-devops/b89bead0-a04d-4cd1-8d8d-a0a4047570af/_workitems/edit/1292). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.